### PR TITLE
feat(modem): MFLT-7965 Add modem fw version metric

### DIFF
--- a/modules/memfault-firmware-sdk/Kconfig
+++ b/modules/memfault-firmware-sdk/Kconfig
@@ -152,7 +152,7 @@ config MEMFAULT_NCS_STACK_METRICS
 config MEMFAULT_NCS_LTE_METRICS
 	bool "Collect LTE metrics"
 	select LTE_LC_TRACE
-	depends on LTE_LINK_CONTROL
+	depends on LTE_LINK_CONTROL && MODEM_INFO
 	help
 	  Capture LTE metrics while the application is running. Supported
 	  metrics are time to connect and number of connection establishments.

--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -1,4 +1,7 @@
 /* Definitions for optional metrics. */
+#if defined(CONFIG_MODEM_INFO)
+#include <modem/modem_info.h>
+#endif
 
 #ifdef CONFIG_MEMFAULT_NCS_STACK_METRICS
 MEMFAULT_METRICS_KEY_DEFINE(Ncs_ConnectionPollUnusedStack, kMemfaultMetricType_Unsigned)
@@ -7,6 +10,9 @@ MEMFAULT_METRICS_KEY_DEFINE(NcsBtTxUnusedStack, kMemfaultMetricType_Unsigned)
 #endif /* CONFIG_MEMFAULT_NCS_STACK_METRICS */
 
 #ifdef CONFIG_MEMFAULT_NCS_LTE_METRICS
+#if defined(CONFIG_MODEM_INFO)
+MEMFAULT_METRICS_STRING_KEY_DEFINE(Ncs_LteFwVersion, MODEM_INFO_FWVER_SIZE)
+#endif
 MEMFAULT_METRICS_KEY_DEFINE(Ncs_LteTimeToConnect, kMemfaultMetricType_Timer)
 MEMFAULT_METRICS_KEY_DEFINE(Ncs_LteConnectionLossCount, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(Ncs_LtePsmTauSec, kMemfaultMetricType_Signed)

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -9,6 +9,9 @@
 
 #include <modem/lte_lc.h>
 #include <modem/lte_lc_trace.h>
+#if defined(CONFIG_MODEM_INFO)
+#include <modem/modem_info.h>
+#endif
 
 #include <memfault/metrics/metrics.h>
 #include <memfault/core/platform/overrides.h>
@@ -160,6 +163,12 @@ void memfault_lte_metrics_init(void)
 {
 	lte_lc_trace_handler_set(lte_trace_cb);
 	lte_lc_register_handler(lte_handler);
+
+#if defined(CONFIG_MODEM_INFO)
+	char buf[MODEM_INFO_FWVER_SIZE];
+	modem_info_get_fw_version(buf, ARRAY_SIZE(buf));
+	memfault_metrics_heartbeat_set_string(MEMFAULT_METRICS_KEY(Ncs_LteFwVersion), buf);
+#endif
 
 #if CONFIG_MEMFAULT_NCS_STACK_METRICS
 	int err;


### PR DESCRIPTION
feat(modem): [MFLT-7965](https://memfault.myjetbrains.com/youtrack/issue/MFLT-7965/Post-modem-fw-version-for-nRF9160-port) Add modem fw version metric

## Summary

It is useful to have the modem firmware in a device attribute since
that firmware is independently flashable from the main application
and there's a requirement for it to be compatible. Upon boot, the
modem firmware version is fetched and a string metric is updated
with this value. The first heartbeat will have this value, and it will
be viewable as an attribute.

## Test Plan

Tested by capturing a heartbeat before and after an update to the
modem firmware to see the reported version change.

Before:
<img width="567" alt="before" src="https://github.com/memfault/sdk-nrf/assets/41022382/f2f92d56-29e7-424c-8eca-8ccf313ef3f8">

After:
<img width="576" alt="after" src="https://github.com/memfault/sdk-nrf/assets/41022382/5b89dfb8-be98-4649-bc10-c91da856de3e">

Changes to the Kconfig with a new dependency were tested by removing `CONFIG_MODEM_INFO` from both `sdk/embedded/examples/nrf-connect-sdk/nrf9160/memfault_demo_app/CMakeLists.txt` and `sdk-nrf/modules/memfault-firmware-sdk/Kconfig`. The following warning is generated:

<img width="814" alt="Screenshot 2023-08-28 at 11 37 13 AM" src="https://github.com/memfault/sdk-nrf/assets/41022382/76d17563-1e5b-4a4d-a264-83ee244e98e4">

Warning goes away after re-adding `CONFIG_MODEM_INFO`.