### PR TITLE
Add operator name to LTE metrics

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -45,6 +45,13 @@ extern "C" {
 
 #define BAND_UNAVAILABLE 0
 
+// TODO: Confirm - there is no clear guidance in nrf9160 AT command
+// guide - 3GPP gives an upper limit on the full name size but the
+// short name is not specified. This may be a Nordic-defined limit,
+// so for now guess a medium length to give some room.
+/** Short operator size can be up to 15 characters long. */
+#define MODEM_INFO_MAX_SHORT_OP_NAME_SIZE 16
+
 /** Modem returns RSRP and RSRQ as index values which require
  * a conversion to dBm and dB respectively. See modem AT
  * command reference guide for more information.
@@ -362,6 +369,16 @@ int modem_info_get_connectivity_stats(int *tx_kbytes, int *rx_kbytes);
  *          Otherwise, a (negative) error code is returned
  */
 int modem_info_get_current_band(uint8_t *band_id);
+
+/**
+ * @brief Obtain the operator name.
+ *
+ * @param buf Buffer to store operator name in
+ * @param len Length of the buffer
+ * @return 0 if operation was successful.
+ *          Otherwise, a (negative) error code is returned
+ */
+int modem_info_get_operator(char *buf, size_t len);
 
 /** @} */
 

--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -28,6 +28,7 @@ MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_tx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_rx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_reset_loop_detected_count, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_band, kMemfaultMetricType_Unsigned)
+MEMFAULT_METRICS_STRING_KEY_DEFINE(ncs_lte_operator, MODEM_INFO_MAX_SHORT_OP_NAME_SIZE)
 #endif /* CONFIG_MEMFAULT_NCS_LTE_METRICS */
 
 #ifdef CONFIG_MEMFAULT_NCS_BT_METRICS

--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -14,6 +14,7 @@ MEMFAULT_METRICS_KEY_DEFINE(NcsBtTxUnusedStack, kMemfaultMetricType_Unsigned)
 
 #if defined(CONFIG_MODEM_INFO)
 MEMFAULT_METRICS_STRING_KEY_DEFINE(Ncs_LteModemFwVersion, MODEM_INFO_FWVER_SIZE)
+MEMFAULT_METRICS_STRING_KEY_DEFINE(ncs_lte_operator, MODEM_INFO_MAX_SHORT_OP_NAME_SIZE)
 #endif /* defined(CONFIG_MODEM_INFO) */
 
 MEMFAULT_METRICS_KEY_DEFINE(Ncs_LteTimeToConnect, kMemfaultMetricType_Timer)
@@ -28,7 +29,6 @@ MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_tx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_rx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_reset_loop_detected_count, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_band, kMemfaultMetricType_Unsigned)
-MEMFAULT_METRICS_STRING_KEY_DEFINE(ncs_lte_operator, MODEM_INFO_MAX_SHORT_OP_NAME_SIZE)
 #endif /* CONFIG_MEMFAULT_NCS_LTE_METRICS */
 
 #ifdef CONFIG_MEMFAULT_NCS_BT_METRICS

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -104,6 +104,19 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 	  err = memfault_metrics_heartbeat_set_unsigned(MEMFAULT_METRICS_KEY(ncs_lte_band), band);
 	  if (err) {
 			LOG_ERR("Failed to set nce_lte_band");
+    }
+  }
+  
+  // Get the operator
+  char operator_name[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE];
+  err = modem_info_get_operator(operator_name, sizeof(operator_name));
+  if (err != 0) {
+	  LOG_WRN("Network operator collection failed, error: %d", err);
+  } else {
+	  err = memfault_metrics_heartbeat_set_string(MEMFAULT_METRICS_KEY(ncs_lte_operator),
+						      operator_name);
+	  if (err) {
+		  LOG_ERR("Failed to set ncs_lte_operator");
 	  }
   }
 

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -107,6 +107,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
     }
   }
   
+#if defined(CONFIG_MODEM_INFO)
   // Get the operator
   char operator_name[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE];
   err = modem_info_get_operator(operator_name, sizeof(operator_name));
@@ -119,6 +120,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		  LOG_ERR("Failed to set ncs_lte_operator");
 	  }
   }
+#endif
 
 	switch (evt->type) {
 	case LTE_LC_EVT_NW_REG_STATUS:

--- a/tests/lib/modem_info/src/main.c
+++ b/tests/lib/modem_info/src/main.c
@@ -39,6 +39,7 @@ FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_cmd, void *, size_t, const char *, ...)
 #define EXAMPLE_BAND_MAX_VAL 71
 #define EXAMPLE_ONE_LETTER_OPERATOR_NAME "O"
 #define EXAMPLE_SHORT_OPERATOR_NAME "OP"
+#define EXAMPLE_TOO_LARGE_OPERATOR_NAME "TOO_LARGE_OPERATOR_NAME"
 
 // TODO: Confirm - this is an educated guess at the moment, based upon various
 // #define values in the library. Get input from Nordic on this later.
@@ -211,11 +212,8 @@ static int nrf_modem_at_cmd_custom_xmonitor_too_large_operator(void *buf, size_t
 	TEST_ASSERT_EQUAL_STRING("AT%%XMONITOR", fmt);
 
 	// Construct the response
-	char operator_name[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE + 1];
-	memset(operator_name, 'S', sizeof(operator_name));
-	operator_name[sizeof(operator_name) - 1] = '\0';
 	char xmonitor_resp[XMONITOR_CMD_MAX_RESPONSE_LEN] = "%XMONITOR: 1,\"Operator\",\"";
-	strcat(xmonitor_resp, operator_name);
+	strcat(xmonitor_resp, EXAMPLE_TOO_LARGE_OPERATOR_NAME);
 	strcat(xmonitor_resp, "\",\"20065\",\"4321\",7,20,\"12345678\",334,6200,66,44,\"\","
 			      "\"11100000\",\"00010011\",\"01001001\"");
 
@@ -624,11 +622,16 @@ void test_modem_info_get_operator_empty(void)
 void test_modem_info_get_operator_too_large(void)
 {
 	char buffer[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE];
+	char at_cmd_response[] = EXAMPLE_TOO_LARGE_OPERATOR_NAME;
+	char expected_substr[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE];
+	strncpy(expected_substr, at_cmd_response, MODEM_INFO_MAX_SHORT_OP_NAME_SIZE - 1);
+	expected_substr[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE - 1] = '\0';
 
 	nrf_modem_at_cmd_fake.custom_fake = nrf_modem_at_cmd_custom_xmonitor_too_large_operator;
 
 	int ret = modem_info_get_operator(buffer, sizeof(buffer));
-	TEST_ASSERT_EQUAL(-ERANGE, ret);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL_STRING(expected_substr, buffer);
 	TEST_ASSERT_EQUAL(1, nrf_modem_at_cmd_fake.call_count);
 }
 


### PR DESCRIPTION
## Summary

The operator name is a critical piece of data to have when debugging
LTE issues. This commit adds the collection of the operator/carrier
name. The "short name" is being pulled from the `XMONITOR`
Nordic AT command to keep the number of bytes in the metrics
as low as possible. There isn't a clear max length for this short name,
so guessing 15 for now, and marking a TODO to confirm later.

##  Test Plan

- Added unit tests to modem info module unit tests:

<details>
    <summary>Unit test results</summary>
<pre><code>
(.venv) nrf/tests/lib/modem_info$ west build -b native_posix -t run
-- west build: running target run
[5/6] cd /home/gminn/thingy91-workspace/nrf/tests/lib/modem_info/build && /home/gminn/thingy91-workspace/nrf/tests/lib/modem_info/build/zephyr/zephyr.exe
*** Booting nRF Connect SDK 3d4d9ad76e09 ***
src/main.c:277:test_modem_info_init_success:PASS
src/main.c:287:test_modem_info_get_fw_uuid_null:PASS
src/main.c:296:test_modem_info_get_fw_uuid_buf_too_small:PASS
src/main.c:306:test_modem_info_get_fw_uuid_at_returns_error:PASS
src/main.c:318:test_modem_info_get_fw_uuid_success:PASS
src/main.c:331:test_modem_info_get_fw_version_null:PASS
src/main.c:340:test_modem_info_get_fw_version_buf_too_small:PASS
src/main.c:352:test_modem_info_get_fw_version_at_returns_error:PASS
src/main.c:364:test_modem_info_get_fw_version_success:PASS
src/main.c:377:test_modem_info_get_svn_null:PASS
src/main.c:386:test_modem_info_get_svn_buf_too_small:PASS
src/main.c:396:test_modem_info_get_svn_at_returns_error:PASS
src/main.c:408:test_modem_info_get_svn_success:PASS
src/main.c:421:test_modem_info_get_batt_voltage_null:PASS
src/main.c:430:test_modem_info_get_batt_voltage_at_returns_error:PASS
src/main.c:442:test_modem_info_get_batt_voltage_success:PASS
src/main.c:455:test_modem_info_get_temperature_null:PASS
src/main.c:464:test_modem_info_get_temperature_at_returns_error:PASS
src/main.c:476:test_modem_info_get_temperature_success:PASS
src/main.c:489:test_modem_info_get_rsrp_null:PASS
src/main.c:498:test_modem_info_get_rsrp_at_returns_error:PASS
src/main.c:510:test_modem_info_get_rsrp_invalid_rsrp:PASS
src/main.c:523:test_modem_info_get_rsrp_success:PASS
src/main.c:536:test_modem_info_get_current_band_null:PASS
src/main.c:543:test_modem_info_get_current_band_success:PASS
src/main.c:555:test_modem_info_get_current_band_success_max_val:PASS
src/main.c:567:test_modem_info_get_current_band_unavailable:PASS
src/main.c:577:test_modem_info_get_current_band_at_cmd_error:PASS
src/main.c:587:test_modem_info_get_operator_invalid_null_buf:PASS
src/main.c:594:test_modem_info_get_operator_invalid_buffer_len:PASS
src/main.c:602:test_modem_info_get_operator_none:PASS
src/main.c:613:test_modem_info_get_operator_empty:PASS
src/main.c:624:test_modem_info_get_operator_one_letter:PASS
src/main.c:636:test_modem_info_get_operator_too_large:PASS
src/main.c:647:test_modem_info_get_operator_shortname_success:PASS

-----------------------
35 Tests 0 Failures 0 Ignored
OK
PROJECT EXECUTION SUCCESSFUL
</code></pre></p>
</details>

- Flashed a Thingy91 and obtained the carrier name, checked for successful upload
to memfault:

<img width="455" alt="Screenshot 2023-11-07 at 5 45 32 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/d9877baa-643b-4d96-bf83-707100a43e7f">

Had hoped to see more carriers over the course of the last 24 hours, but we'll
do more dog fooding later for further testing.