### PR TITLE
Add metric to count reset loop detections by modem

### DIFF
--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -26,6 +26,7 @@ MEMFAULT_METRICS_KEY_DEFINE(Ncs_LteMode, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(Ncs_LteRsrp, kMemfaultMetricType_Signed)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_tx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_rx_kilobytes, kMemfaultMetricType_Unsigned)
+MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_reset_loop_detected_count, kMemfaultMetricType_Unsigned)
 #endif /* CONFIG_MEMFAULT_NCS_LTE_METRICS */
 
 #ifdef CONFIG_MEMFAULT_NCS_BT_METRICS

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -189,6 +189,11 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		}
 
 		break;
+	case LTE_LC_EVT_MODEM_EVENT:
+		if (evt->modem_evt == LTE_LC_MODEM_EVT_RESET_LOOP) {
+			MEMFAULT_HEARTBEAT_ADD(ncs_lte_reset_loop_detected_count, 1);
+		}
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
### Summary

When the modem detects a reset loop, it will prevent the device from attaching
to the network for 30 minutes. This is a rough state to be in, and knowing if it
happens and how many times in a heartbeat or session will be useful to be
aware of. This item plus hopefully some other information that a customer
plugs in like some reset reasons and perhaps a coredump could help with
diagnosis.

A pathological case where this wouldn't actually be useful:
device is stuck in reset loop, resetting often enough that the device doesn't store
a heartbeat in this window. Even if a heartbeat is collected before resetting, it would
need to be stored in non-volatile memory, otherwise we'll lose this information entirely.
Even after that, the device would then need to recover somehow to eventually 
be able to send up this info. Device might be totally hosed at this point but worth
a note.

### Test Plan

Experienced a reset loop on a Thingy91, and checked that the metric was incremented
on boot:

```
[00:00:01.809,478] <wrn> modem_module: The modem has detected a reset loop. LTE network attach is now restricted for the next 30 minutes. Power-cycle the device to circumvent this restriction.
```

Triggered a heartbeat dump with `mflt heartbeat_dump`

```
[00:01:26.859,863] <inf> mflt:   ncs_lte_tx_kilobytes: 0
[00:01:26.859,954] <inf> mflt:   ncs_lte_rx_kilobytes: 0
[00:01:26.860,015] <inf> mflt:   ncs_lte_reset_loop_detected_count: 1
```