### PR TITLE
Add LTE frequency band metric

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -43,6 +43,8 @@ extern "C" {
 /** Modem firmware version string can be up to 40 characters long. */
 #define MODEM_INFO_FWVER_SIZE 41
 
+#define BAND_UNAVAILABLE 0
+
 /** Modem returns RSRP and RSRQ as index values which require
  * a conversion to dBm and dB respectively. See modem AT
  * command reference guide for more information.
@@ -351,6 +353,15 @@ int modem_info_get_rsrp(int *val);
  * @return 0 if operation was successful
  */
 int modem_info_get_connectivity_stats(int *tx_kbytes, int *rx_kbytes);
+
+/**
+ * @brief Obtain the current band
+ *
+ * @param band_id id of the current band
+ * @return int 0 if operation was sucessful.
+ *          Otherwise, a (negative) error code is returned
+ */
+int modem_info_get_current_band(uint8_t *band_id);
 
 /** @} */
 

--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -358,7 +358,7 @@ int modem_info_get_connectivity_stats(int *tx_kbytes, int *rx_kbytes);
  * @brief Obtain the current band
  *
  * @param band_id id of the current band
- * @return int 0 if operation was sucessful.
+ * @return 0 if operation was sucessful.
  *          Otherwise, a (negative) error code is returned
  */
 int modem_info_get_current_band(uint8_t *band_id);

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -944,7 +944,7 @@ int modem_info_get_current_band(uint8_t *band)
 	}
 
 	if (*band == BAND_UNAVAILABLE) {
-		return -1;
+		return -ENOMSG;
 	}
 
 	return 0;

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -931,6 +931,25 @@ int modem_info_get_connectivity_stats(int *tx_kbytes, int *rx_kbytes)
 	return 0;
 }
 
+int modem_info_get_current_band(uint8_t *band)
+{
+	if (band == NULL) {
+		return -EINVAL;
+	}
+
+	int ret = nrf_modem_at_scanf("AT%XCBAND", "%%XCBAND: %u", band);
+
+	if (ret != 1) {
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+
+	if (*band == BAND_UNAVAILABLE) {
+		return -1;
+	}
+
+	return 0;
+}
+
 int modem_info_init(void)
 {
 	int err = 0;

--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -27,6 +27,7 @@ MEMFAULT_METRICS_KEY_DEFINE(Ncs_LteRsrp, kMemfaultMetricType_Signed)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_tx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_rx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_reset_loop_detected_count, kMemfaultMetricType_Unsigned)
+MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_band, kMemfaultMetricType_Unsigned)
 #endif /* CONFIG_MEMFAULT_NCS_LTE_METRICS */
 
 #ifdef CONFIG_MEMFAULT_NCS_BT_METRICS

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -96,6 +96,17 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		}
   }
 
+  uint8_t band;
+  err = modem_info_get_current_band(&band);
+  if (err != 0) {
+		LOG_WRN("Network band collection failed, error: %d", err);
+  } else {
+	  err = memfault_metrics_heartbeat_set_unsigned(MEMFAULT_METRICS_KEY(ncs_lte_band), band);
+	  if (err) {
+			LOG_ERR("Failed to set nce_lte_band");
+	  }
+  }
+
 	switch (evt->type) {
 	case LTE_LC_EVT_NW_REG_STATUS:
 		switch (evt->nw_reg_status) {

--- a/tests/lib/modem_info/src/main.c
+++ b/tests/lib/modem_info/src/main.c
@@ -16,6 +16,7 @@
 #include <zephyr/fff.h>
 
 #include <nrf_modem_at.h>
+#include <nrf_errno.h>
 
 DEFINE_FFF_GLOBALS;
 
@@ -33,6 +34,8 @@ FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_scanf, const char *, const char *, ...)
 #define EXAMPLE_RSRP_INVALID 255
 #define EXAMPLE_RSRP_VALID 160
 #define RSRP_OFFSET 140
+#define EXAMPLE_BAND	     13
+#define EXAMPLE_BAND_MAX_VAL 71
 
 struct at_param at_params[10] = {};
 static struct at_param_list m_param_list = {
@@ -129,6 +132,48 @@ static int nrf_modem_at_scanf_custom_cesq_invalid(const char *cmd, const char *f
 	return 1;
 }
 
+static int nrf_modem_at_scanf_custom_xcband(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%XCBAND", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%XCBAND: %u", fmt);
+
+	uint8_t *val = va_arg(args, uint8_t *);
+	*val = EXAMPLE_BAND;
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_xcband_max_val(const char *cmd, const char *fmt, va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%XCBAND", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%XCBAND: %u", fmt);
+
+	uint8_t *val = va_arg(args, uint8_t *);
+	*val = EXAMPLE_BAND_MAX_VAL;
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_xcband_unavailable(const char *cmd, const char *fmt,
+							va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%XCBAND", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%XCBAND: %u", fmt);
+
+	uint8_t *val = va_arg(args, uint8_t *);
+	*val = BAND_UNAVAILABLE;
+
+	return 1;
+}
+
+static int nrf_modem_at_scanf_custom_xcband_at_cmd_error(const char *cmd, const char *fmt,
+							 va_list args)
+{
+	TEST_ASSERT_EQUAL_STRING("AT%XCBAND", cmd);
+	TEST_ASSERT_EQUAL_STRING("%%XCBAND: %u", fmt);
+
+	return -NRF_EBADMSG; // no arguments matched
+}
 
 void setUp(void)
 {
@@ -403,6 +448,57 @@ void test_modem_info_get_rsrp_success(void)
 	ret = modem_info_get_rsrp(&val);
 	TEST_ASSERT_EQUAL(EXIT_SUCCESS, ret);
 	TEST_ASSERT_EQUAL(EXAMPLE_RSRP_VALID-RSRP_OFFSET, val);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_current_band_null(void)
+{
+	int ret = modem_info_get_current_band(NULL);
+	TEST_ASSERT_EQUAL(-EINVAL, ret);
+	TEST_ASSERT_EQUAL(0, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_current_band_success(void)
+{
+	uint8_t band;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_xcband;
+
+	int ret = modem_info_get_current_band(&band);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(EXAMPLE_BAND, band);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_current_band_success_max_val(void)
+{
+	uint8_t band;
+
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_xcband_max_val;
+
+	int ret = modem_info_get_current_band(&band);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(EXAMPLE_BAND_MAX_VAL, band);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_current_band_unavailable(void)
+{
+	uint8_t band;
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_xcband_unavailable;
+
+	int ret = modem_info_get_current_band(&band);
+	TEST_ASSERT_EQUAL(-1, ret);
+	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
+}
+
+void test_modem_info_get_current_band_at_cmd_error(void)
+{
+	uint8_t band;
+	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_xcband_at_cmd_error;
+
+	int ret = modem_info_get_current_band(&band);
+	TEST_ASSERT_EQUAL(-EBADMSG, ret); // the generic posix error should get returned
 	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
 }
 

--- a/tests/lib/modem_info/src/main.c
+++ b/tests/lib/modem_info/src/main.c
@@ -34,7 +34,7 @@ FAKE_VALUE_FUNC_VARARG(int, nrf_modem_at_scanf, const char *, const char *, ...)
 #define EXAMPLE_RSRP_INVALID 255
 #define EXAMPLE_RSRP_VALID 160
 #define RSRP_OFFSET 140
-#define EXAMPLE_BAND	     13
+#define EXAMPLE_BAND 13
 #define EXAMPLE_BAND_MAX_VAL 71
 
 struct at_param at_params[10] = {};
@@ -488,7 +488,7 @@ void test_modem_info_get_current_band_unavailable(void)
 	nrf_modem_at_scanf_fake.custom_fake = nrf_modem_at_scanf_custom_xcband_unavailable;
 
 	int ret = modem_info_get_current_band(&band);
-	TEST_ASSERT_EQUAL(-1, ret);
+	TEST_ASSERT_EQUAL(-ENOMSG, ret);
 	TEST_ASSERT_EQUAL(1, nrf_modem_at_scanf_fake.call_count);
 }
 


### PR DESCRIPTION
### Summary

Add the current frequency band as an LTE metric. These integers map
to a 3GPP frequency band, which are defined in 3GPP Tech
Spec 36.101, and are widely referenced across the web ([here](https://awt-global.com/wp3/resources/lte-e-utran-bands/), for example).

Frequency band allocation vary based on the provider and the
geographic area. Different bands have varying signal propagation,
and coverage, therefore heavily impact performance. We will continue
to do more research into how the frequency can be used during debugging
and monitoring, but at first glance, users could see which frequency bands
are problematic to either report an issue to the carrier or limit the bands
that the device supports (see the Nordic %XBANDLOCK command).

### Testing Plan

Added unit tests and ran, full pass.

Also, flashed a thingy91 and checked that it was reported correctly. 12 is indeed
one of the LTE bands that AT&T uses, which is the carrier reported by this device [[Source](https://www.phonearena.com/news/Cheat-sheet-which-4G-LTE-bands-do-AT-T-Verizon-T-Mobile-and-Sprint-use-in-the-USA_id77933)].

<img width="377" alt="Screenshot 2023-11-11 at 12 11 31 AM" src="https://github.com/memfault/sdk-nrf/assets/41022382/9abfa78a-7da3-44bb-969c-564bdd0e5872">