### PR TITLE
Add SNR metric

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -43,6 +43,7 @@ extern "C" {
 /** Modem firmware version string can be up to 40 characters long. */
 #define MODEM_INFO_FWVER_SIZE 41
 
+/** Band unavailable value. */
 #define BAND_UNAVAILABLE 0
 
 // TODO: Confirm - there is no clear guidance in nrf9160 AT command
@@ -51,6 +52,12 @@ extern "C" {
 // so for now guess a medium length to give some room.
 /** Short operator size can be up to 15 characters long. */
 #define MODEM_INFO_MAX_SHORT_OP_NAME_SIZE 16
+
+/** SNR unavailable value. */
+#define SNR_UNAVAILABLE	 127
+
+/** SNR offset value. */
+#define SNR_OFFSET_VAL 24
 
 /** Modem returns RSRP and RSRQ as index values which require
  * a conversion to dBm and dB respectively. See modem AT
@@ -379,6 +386,15 @@ int modem_info_get_current_band(uint8_t *band_id);
  *          Otherwise, a (negative) error code is returned
  */
 int modem_info_get_operator(char *buf, size_t len);
+
+/**
+ * @brief Obtain the signal-to-noise ratio
+ *
+ * @param snr current SNR
+ * @return 0 if operation was sucessful.
+ *          Otherwise, a (negative) error code is returned
+ */
+int modem_info_get_snr(int *snr);
 
 /** @} */
 

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -954,7 +954,7 @@ int modem_info_get_current_band(uint8_t *band)
 	}
 
 	if (*band == BAND_UNAVAILABLE) {
-		return -ENOMSG;
+		return -ENOENT;
 	}
 
 	return 0;
@@ -980,6 +980,27 @@ int modem_info_get_operator(char *buf, size_t len)
 	}
 
 	buf[len - 1] = '\0'; // Null terminate
+
+	return 0;
+}
+
+int modem_info_get_snr(int *snr)
+{
+	if (snr == NULL) {
+		return -EINVAL;
+	}
+
+	int ret = nrf_modem_at_scanf("AT%XSNRSQ?", "%%XSNRSQ: %d,%*d,%*d", snr);
+
+	if (ret != 1) {
+		return map_nrf_modem_at_scanf_error(ret);
+	}
+
+	if (*snr == SNR_UNAVAILABLE) {
+		return -ENOENT;
+	}
+
+	*snr -= SNR_OFFSET_VAL;
 
 	return 0;
 }

--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -15,6 +15,7 @@ MEMFAULT_METRICS_KEY_DEFINE(NcsBtTxUnusedStack, kMemfaultMetricType_Unsigned)
 #if defined(CONFIG_MODEM_INFO)
 MEMFAULT_METRICS_STRING_KEY_DEFINE(Ncs_LteModemFwVersion, MODEM_INFO_FWVER_SIZE)
 MEMFAULT_METRICS_STRING_KEY_DEFINE(ncs_lte_operator, MODEM_INFO_MAX_SHORT_OP_NAME_SIZE)
+MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_snr_decibels, kMemfaultMetricType_Signed)
 #endif /* defined(CONFIG_MODEM_INFO) */
 
 MEMFAULT_METRICS_KEY_DEFINE(Ncs_LteTimeToConnect, kMemfaultMetricType_Timer)

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -118,6 +118,21 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 						      operator_name);
 	  if (err) {
 		  LOG_ERR("Failed to set ncs_lte_operator");
+			LOG_ERR("Failed to set ncs_lte_band");
+	  }
+  }
+#endif
+
+#if defined(CONFIG_MODEM_INFO)
+  int snr;
+  err = modem_info_get_snr(&snr);
+  if (err != 0) {
+	  LOG_WRN("SNR collection failed, error: %d", err);
+  } else {
+	  err = memfault_metrics_heartbeat_set_signed(MEMFAULT_METRICS_KEY(ncs_lte_snr_decibels),
+						      snr);
+	  if (err) {
+			LOG_ERR("Failed to set ncs_lte_snr_decibels");
 	  }
   }
 #endif


### PR DESCRIPTION
### Summary

SNR is a connection attribute that gives another indication
of signal quality. It can help identify issues with too much noise
in relation to the LTE signal, which could be caused by other
parts of a system or from its environment.

### Test Plan

- Added to and ran unit tests:

<details>
    <summary>Unit test results</summary>
<pre><code>
(.venv) nrf/tests/lib/modem_info$ west build -b native_posix -t run
-- west build: running target run
[0/7] Generating runner/runner_main.c
[6/7] cd /home/gminn/thingy91-workspace/nrf/tests/lib/modem_info/build && /home/gminn/thingy91-workspace/nrf/tests/lib/modem_info/build/zephyr/zephyr.exe
*** Booting nRF Connect SDK 3d4d9ad76e09 ***
src/main.c:227:test_modem_info_init_success:PASS
src/main.c:237:test_modem_info_get_fw_uuid_null:PASS
src/main.c:246:test_modem_info_get_fw_uuid_buf_too_small:PASS
src/main.c:256:test_modem_info_get_fw_uuid_at_returns_error:PASS
src/main.c:268:test_modem_info_get_fw_uuid_success:PASS
src/main.c:281:test_modem_info_get_fw_version_null:PASS
src/main.c:290:test_modem_info_get_fw_version_buf_too_small:PASS
src/main.c:302:test_modem_info_get_fw_version_at_returns_error:PASS
src/main.c:314:test_modem_info_get_fw_version_success:PASS
src/main.c:327:test_modem_info_get_svn_null:PASS
src/main.c:336:test_modem_info_get_svn_buf_too_small:PASS
src/main.c:346:test_modem_info_get_svn_at_returns_error:PASS
src/main.c:358:test_modem_info_get_svn_success:PASS
src/main.c:371:test_modem_info_get_batt_voltage_null:PASS
src/main.c:380:test_modem_info_get_batt_voltage_at_returns_error:PASS
src/main.c:392:test_modem_info_get_batt_voltage_success:PASS
src/main.c:405:test_modem_info_get_temperature_null:PASS
src/main.c:414:test_modem_info_get_temperature_at_returns_error:PASS
src/main.c:426:test_modem_info_get_temperature_success:PASS
src/main.c:439:test_modem_info_get_rsrp_null:PASS
src/main.c:448:test_modem_info_get_rsrp_at_returns_error:PASS
src/main.c:460:test_modem_info_get_rsrp_invalid_rsrp:PASS
src/main.c:473:test_modem_info_get_rsrp_success:PASS
src/main.c:486:test_modem_info_get_current_band_null:PASS
src/main.c:493:test_modem_info_get_current_band_success:PASS
src/main.c:505:test_modem_info_get_current_band_success_max_val:PASS
src/main.c:517:test_modem_info_get_current_band_unavailable:PASS
src/main.c:527:test_modem_info_get_current_band_at_cmd_error:PASS
src/main.c:537:test_modem_info_get_snr_null:PASS
src/main.c:544:test_modem_info_get_snr_invalid:PASS
src/main.c:555:test_modem_info_get_snr_at_cmd_error:PASS
src/main.c:565:test_modem_info_get_snr_success:PASS

-----------------------
32 Tests 0 Failures 0 Ignored
OK
PROJECT EXECUTION SUCCESSFUL
</code></pre></p>
</details>

- Flashed a Thingy91 and obtained the carrier name, checked for successful upload
to memfault:

<img width="378" alt="Screenshot 2023-11-16 at 2 55 47 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/edd494df-162b-4ca5-b71c-7ef1017bb7d9">
