### PR TITLE
Add simple LTE on time metric

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -23,6 +23,10 @@
 
 #include "lte_lc_helpers.h"
 
+#if defined(CONFIG_MEMFAULT_NCS_LTE_METRICS)
+#include <memfault/metrics/metrics.h>
+#endif
+
 LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
 /* Internal system mode value used when CONFIG_LTE_NETWORK_MODE_DEFAULT is enabled. */
@@ -1443,6 +1447,14 @@ int lte_lc_func_mode_set(enum lte_lc_func_mode mode)
 		LOG_DBG("CFUN monitor callback: %p", e->callback);
 		e->callback(mode, e->context);
 	}
+
+#if defined(CONFIG_MEMFAULT_NCS_LTE_METRICS)
+  if (mode == LTE_LC_FUNC_MODE_NORMAL || mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE) {
+    MEMFAULT_HEARTBEAT_TIMER_START(ncs_lte_on_time_msec);
+  } else if(mode == LTE_LC_FUNC_MODE_POWER_OFF || mode == LTE_LC_FUNC_MODE_OFFLINE || mode == LTE_LC_FUNC_MODE_DEACTIVATE_LTE) {
+    MEMFAULT_HEARTBEAT_TIMER_STOP(ncs_lte_on_time_msec);
+  }
+#endif
 
 	return 0;
 }

--- a/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
+++ b/modules/memfault-firmware-sdk/config/memfault_metrics_heartbeat_extra.def
@@ -28,6 +28,7 @@ MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_tx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_rx_kilobytes, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_reset_loop_detected_count, kMemfaultMetricType_Unsigned)
 MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_band, kMemfaultMetricType_Unsigned)
+MEMFAULT_METRICS_KEY_DEFINE(ncs_lte_on_time_msec, kMemfaultMetricType_Timer)
 #endif /* CONFIG_MEMFAULT_NCS_LTE_METRICS */
 
 #ifdef CONFIG_MEMFAULT_NCS_BT_METRICS


### PR DESCRIPTION
### Summary

Add a simple LTE on-time metric. This is completely dependent
on commands being sent to the modem to jump into a different
mode. Currently does not account for any PSM modes. This is
a first pass and should be refined later given more testing.

### Test Plan

- [x] Test on thingy91

<img width="348" alt="Screenshot 2023-11-16 at 7 17 27 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/72986587-f6a4-48f8-9eae-d2b40d8287d2">
