### PR TITLE
Update metrics to use new API

### DIFF
--- a/applications/asset_tracker_v2/src/modules/debug_module.c
+++ b/applications/asset_tracker_v2/src/modules/debug_module.c
@@ -264,17 +264,13 @@ static void add_location_metrics(uint8_t satellites, uint32_t search_time,
 
 	switch (event) {
 	case LOCATION_MODULE_EVT_GNSS_DATA_READY:
-		err = memfault_metrics_heartbeat_set_unsigned(
-						MEMFAULT_METRICS_KEY(GnssTimeToFix),
-						search_time);
+		err = MEMFAULT_HEARTBEAT_SET_UNSIGNED(GnssTimeToFix, search_time);
 		if (err) {
 			LOG_ERR("Failed updating GnssTimeToFix metric, error: %d", err);
 		}
 		break;
 	case LOCATION_MODULE_EVT_TIMEOUT:
-		err = memfault_metrics_heartbeat_set_unsigned(
-						MEMFAULT_METRICS_KEY(LocationTimeoutSearchTime),
-						search_time);
+		err = MEMFAULT_HEARTBEAT_SET_UNSIGNED(LocationTimeoutSearchTime, search_time);
 		if (err) {
 			LOG_ERR("Failed updating LocationTimeoutSearchTime metric, error: %d", err);
 		}
@@ -284,8 +280,7 @@ static void add_location_metrics(uint8_t satellites, uint32_t search_time,
 		return;
 	}
 
-	err = memfault_metrics_heartbeat_set_unsigned(MEMFAULT_METRICS_KEY(GnssSatellitesTracked),
-						      satellites);
+	err = MEMFAULT_HEARTBEAT_SET_UNSIGNED(GnssSatellitesTracked, satellites);
 	if (err) {
 		LOG_ERR("Failed updating GnssSatellitesTracked metric, error: %d", err);
 	}

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -1450,9 +1450,9 @@ int lte_lc_func_mode_set(enum lte_lc_func_mode mode)
 
 #if defined(CONFIG_MEMFAULT_NCS_LTE_METRICS)
   if (mode == LTE_LC_FUNC_MODE_NORMAL || mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE) {
-    MEMFAULT_HEARTBEAT_TIMER_START(ncs_lte_on_time_msec);
+	  MEMFAULT_METRIC_TIMER_START(ncs_lte_on_time_msec);
   } else if(mode == LTE_LC_FUNC_MODE_POWER_OFF || mode == LTE_LC_FUNC_MODE_OFFLINE || mode == LTE_LC_FUNC_MODE_DEACTIVATE_LTE) {
-    MEMFAULT_HEARTBEAT_TIMER_STOP(ncs_lte_on_time_msec);
+	  MEMFAULT_METRIC_TIMER_STOP(ncs_lte_on_time_msec);
   }
 #endif
 

--- a/modules/memfault-firmware-sdk/memfault_bt_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_bt_metrics.c
@@ -40,8 +40,7 @@ void connected(struct bt_conn *conn, uint8_t conn_err)
 
 	if (conn_err == 0) {
 		if (count == 0) {
-			err = memfault_metrics_heartbeat_timer_start(
-					MEMFAULT_METRICS_KEY(Ncs_BtConnectionTime));
+			err = MEMFAULT_METRIC_TIMER_START(Ncs_BtConnectionTime);
 			if (err) {
 				LOG_WRN("Failed to start memfault Ncs_BtConnectionTime timer, "
 				"err: %d", err);
@@ -60,8 +59,7 @@ void disconnected(struct bt_conn *conn, uint8_t reason)
 	__ASSERT_NO_MSG(count > 0);
 
 	if (count == 1) {
-		err = memfault_metrics_heartbeat_timer_stop(
-				MEMFAULT_METRICS_KEY(Ncs_BtConnectionTime));
+		err = MEMFAULT_METRIC_TIMER_STOP(Ncs_BtConnectionTime);
 		if (err) {
 			LOG_WRN("Failed to stop memfault Ncs_BtConnectionTime timer, err: %d", err);
 		}
@@ -117,14 +115,12 @@ void memfault_bt_metrics_update(void)
 
 	LOG_DBG("Current bond count: %u", bond_count);
 
-	err = memfault_metrics_heartbeat_set_unsigned(MEMFAULT_METRICS_KEY(Ncs_BtBondCount),
-						      bond_count);
+	err = MEMFAULT_METRIC_SET_UNSIGNED(Ncs_BtBondCount, bond_count);
 	if (err) {
 		LOG_WRN("Failed to set the Ncs_BtBondCount metric, err: %d", err);
 	}
 
-	err = memfault_metrics_heartbeat_set_unsigned(MEMFAULT_METRICS_KEY(Ncs_BtConnectionCount),
-						      atomic_get(&connection_count));
+	err = MEMFAULT_METRIC_SET_UNSIGNED(Ncs_BtConnectionCount, atomic_get(&connection_count));
 	if (err) {
 		LOG_WRN("Failed to set Ncs_BtConnectionCount metrics, err: %d", err);
 	}

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -45,8 +45,7 @@ static void lte_trace_cb(enum lte_lc_trace_type type)
 			break;
 		}
 
-		err = memfault_metrics_heartbeat_timer_start(
-			MEMFAULT_METRICS_KEY(Ncs_LteTimeToConnect));
+		err = MEMFAULT_METRIC_TIMER_START(Ncs_LteTimeToConnect);
 		if (err) {
 			LOG_WRN("LTE connection time tracking was not started, error: %d", err);
 		} else {
@@ -63,78 +62,73 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 {
 	int err;
 
-  // Get signal strength value whenever an event is handled
-  int rsrp;
-  err = modem_info_get_rsrp(&rsrp);
-  if(err) {
-    LOG_WRN("LTE RSRP value collection failed, error: %d", err);
-  } else {
-    err = memfault_metrics_heartbeat_set_signed(
-			MEMFAULT_METRICS_KEY(Ncs_LteRsrp), rsrp);
+	// Get signal strength value whenever an event is handled
+	int rsrp;
+	err = modem_info_get_rsrp(&rsrp);
+	if (err) {
+		LOG_WRN("LTE RSRP value collection failed, error: %d", err);
+	} else {
+		err = MEMFAULT_METRIC_SET_SIGNED(Ncs_LteRsrp, rsrp);
 		if (err) {
 			LOG_ERR("Failed to set Ncs_LteRsrp");
 		}
-  };
+	};
 
-  // Get connectivity stats (data tx and rx)
-  int tx_kbytes;
-  int rx_kybtes;
-  err = modem_info_get_connectivity_stats(&tx_kbytes, &rx_kybtes);
-  if (err) {
+	// Get connectivity stats (data tx and rx)
+	int tx_kbytes;
+	int rx_kybtes;
+	err = modem_info_get_connectivity_stats(&tx_kbytes, &rx_kybtes);
+	if (err) {
 		LOG_WRN("LTE connectivity stats collections failed, error: %d", err);
-  } else {
-		err = memfault_metrics_heartbeat_set_unsigned(
-			MEMFAULT_METRICS_KEY(ncs_lte_tx_kilobytes), tx_kbytes);
+	} else {
+		err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_lte_tx_kilobytes, tx_kbytes);
 		if (err) {
 			LOG_ERR("Failed to set ncs_lte_tx_kilobytes");
 		}
 
-		err = memfault_metrics_heartbeat_set_unsigned(
-			MEMFAULT_METRICS_KEY(ncs_lte_rx_kilobytes), rx_kybtes);
+		err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_lte_rx_kilobytes, rx_kybtes);
 		if (err) {
 			LOG_ERR("Failed to set ncs_lte_rx_kilobytes");
 		}
-  }
+	}
 
-  uint8_t band;
-  err = modem_info_get_current_band(&band);
-  if (err != 0) {
+	uint8_t band;
+	err = modem_info_get_current_band(&band);
+	if (err != 0) {
 		LOG_WRN("Network band collection failed, error: %d", err);
-  } else {
-	  err = memfault_metrics_heartbeat_set_unsigned(MEMFAULT_METRICS_KEY(ncs_lte_band), band);
-	  if (err) {
+	} else {
+		err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_lte_band, band);
+		if (err) {
 			LOG_ERR("Failed to set nce_lte_band");
-    }
-  }
-  
+		}
+	}
+
 #if defined(CONFIG_MODEM_INFO)
-  // Get the operator
-  char operator_name[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE];
-  err = modem_info_get_operator(operator_name, sizeof(operator_name));
-  if (err != 0) {
-	  LOG_WRN("Network operator collection failed, error: %d", err);
-  } else {
-	  err = memfault_metrics_heartbeat_set_string(MEMFAULT_METRICS_KEY(ncs_lte_operator),
-						      operator_name);
-	  if (err) {
-		  LOG_ERR("Failed to set ncs_lte_operator");
+	// Get the operator
+	char operator_name[MODEM_INFO_MAX_SHORT_OP_NAME_SIZE];
+	err = modem_info_get_operator(operator_name, sizeof(operator_name));
+	if (err != 0) {
+		LOG_WRN("Network operator collection failed, error: %d", err);
+	} else {
+		err = MEMFAULT_METRIC_SET_STRING(ncs_lte_operator, operator_name);
+		if (err) {
+			LOG_ERR("Failed to set ncs_lte_operator");
 			LOG_ERR("Failed to set ncs_lte_band");
-	  }
-  }
+		}
+	}
 #endif
 
 #if defined(CONFIG_MODEM_INFO)
-  int snr;
-  err = modem_info_get_snr(&snr);
-  if (err != 0) {
-	  LOG_WRN("SNR collection failed, error: %d", err);
-  } else {
-	  err = memfault_metrics_heartbeat_set_signed(MEMFAULT_METRICS_KEY(ncs_lte_snr_decibels),
-						      snr);
-	  if (err) {
+	int snr;
+	err = modem_info_get_snr(&snr);
+	if (err != 0) {
+		LOG_WRN("SNR collection failed, error: %d", err);
+	} else {
+		err = MEMFAULT_METRIC_SET_SIGNED(ncs_lte_snr_decibels, snr);
+		if (err) {
 			LOG_ERR("Failed to set ncs_lte_snr_decibels");
-	  }
-  }
+		}
+	}
 #endif
 
 	switch (evt->type) {
@@ -150,8 +144,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 				break;
 			}
 
-			err = memfault_metrics_heartbeat_timer_stop(
-				MEMFAULT_METRICS_KEY(Ncs_LteTimeToConnect));
+			err = MEMFAULT_METRIC_TIMER_STOP(Ncs_LteTimeToConnect);
 			if (err) {
 				LOG_WRN("Failed to stop LTE connection timer, error: %d", err);
 			} else {
@@ -166,8 +159,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		case LTE_LC_NW_REG_UNKNOWN:
 		case LTE_LC_NW_REG_UICC_FAIL:
 			if (connected) {
-				err = memfault_metrics_heartbeat_add(
-					MEMFAULT_METRICS_KEY(Ncs_LteConnectionLossCount), 1);
+				err = MEMFAULT_METRIC_ADD(Ncs_LteConnectionLossCount, 1);
 				if (err) {
 					LOG_ERR("Failed to increment Ncs_LteConnectionLossCount");
 				}
@@ -176,8 +168,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 					break;
 				}
 
-				err = memfault_metrics_heartbeat_timer_start(
-					MEMFAULT_METRICS_KEY(Ncs_LteTimeToConnect));
+				err = MEMFAULT_METRIC_TIMER_START(Ncs_LteTimeToConnect);
 				if (err) {
 					LOG_WRN("Failed to start LTE connection timer, error: %d",
 						err);
@@ -193,38 +184,33 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 			break;
 		}
 	case LTE_LC_EVT_PSM_UPDATE:
-		err = memfault_metrics_heartbeat_set_signed(
-			MEMFAULT_METRICS_KEY(Ncs_LtePsmTauSec), evt->psm_cfg.tau);
+		err = MEMFAULT_METRIC_SET_SIGNED(Ncs_LtePsmTauSec, evt->psm_cfg.tau);
 		if (err) {
 			LOG_ERR("Failed to set Ncs_LtePsmTau");
 		}
 
-		err = memfault_metrics_heartbeat_set_signed(
-			MEMFAULT_METRICS_KEY(Ncs_LtePsmActiveTimeSec), evt->psm_cfg.active_time);
+		err = MEMFAULT_METRIC_SET_SIGNED(Ncs_LtePsmActiveTimeSec, evt->psm_cfg.active_time);
 		if (err) {
 			LOG_ERR("Failed to set Ncs_LtePsmActiveTime");
 		}
 
 		break;
 	case LTE_LC_EVT_EDRX_UPDATE:
-		err = memfault_metrics_heartbeat_set_unsigned(
-			MEMFAULT_METRICS_KEY(Ncs_LteEdrxIntervalMsec),
-					     (uint32_t)(evt->edrx_cfg.edrx * MSEC_PER_SEC));
+		err = MEMFAULT_METRIC_SET_UNSIGNED(Ncs_LteEdrxIntervalMsec,
+						   (uint32_t)(evt->edrx_cfg.edrx * MSEC_PER_SEC));
 		if (err) {
 			LOG_ERR("Failed to set Ncs_LteEdrxInterval");
 		}
 
-		err = memfault_metrics_heartbeat_set_unsigned(
-			MEMFAULT_METRICS_KEY(Ncs_LteEdrxPtwMsec),
-					     (uint32_t)(evt->edrx_cfg.ptw * MSEC_PER_SEC));
+		err = MEMFAULT_METRIC_SET_UNSIGNED(Ncs_LteEdrxPtwMsec,
+						   (uint32_t)(evt->edrx_cfg.ptw * MSEC_PER_SEC));
 		if (err) {
 			LOG_ERR("Failed to set Ncs_LteEdrxPtw");
 		}
 
 		break;
 	case LTE_LC_EVT_LTE_MODE_UPDATE:
-		err = memfault_metrics_heartbeat_set_unsigned(
-			MEMFAULT_METRICS_KEY(Ncs_LteMode), evt->lte_mode);
+		err = MEMFAULT_METRIC_SET_UNSIGNED(Ncs_LteMode, evt->lte_mode);
 		if (err) {
 			LOG_ERR("Failed to set Ncs_LteMode");
 		}
@@ -232,7 +218,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		break;
 	case LTE_LC_EVT_MODEM_EVENT:
 		if (evt->modem_evt == LTE_LC_MODEM_EVT_RESET_LOOP) {
-			MEMFAULT_HEARTBEAT_ADD(ncs_lte_reset_loop_detected_count, 1);
+			MEMFAULT_METRIC_ADD(ncs_lte_reset_loop_detected_count, 1);
 		}
 		break;
 	default:
@@ -253,7 +239,7 @@ void memfault_lte_metrics_init(void)
 	/* Ensure null-termination */
 	buf[sizeof(buf) - 1] = '\0';
 
-	memfault_metrics_heartbeat_set_string(MEMFAULT_METRICS_KEY(Ncs_LteModemFwVersion), buf);
+	MEMFAULT_METRIC_SET_STRING(Ncs_LteModemFwVersion, buf);
 
 	int err = modem_info_connectivity_stats_init();
 	if (err) {
@@ -279,14 +265,12 @@ void memfault_lte_metrics_update(void)
 	if (err) {
 		LOG_WRN("LTE connectivity stats collections failed, error: %d", err);
 	} else {
-		err = memfault_metrics_heartbeat_set_unsigned(
-			MEMFAULT_METRICS_KEY(ncs_lte_tx_kilobytes), tx_kbytes);
+		err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_lte_tx_kilobytes, tx_kbytes);
 		if (err) {
 			LOG_ERR("Failed to set ncs_lte_tx_kilobytes");
 		}
 
-		err = memfault_metrics_heartbeat_set_unsigned(
-			MEMFAULT_METRICS_KEY(ncs_lte_rx_kilobytes), rx_kybtes);
+		err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_lte_rx_kilobytes, rx_kybtes);
 		if (err) {
 			LOG_ERR("Failed to set ncs_lte_rx_kilobytes");
 		}

--- a/samples/bluetooth/peripheral_mds/src/main.c
+++ b/samples/bluetooth/peripheral_mds/src/main.c
@@ -173,14 +173,12 @@ static void button_handler(uint32_t button_state, uint32_t has_changed)
 		time_measure_start = !time_measure_start;
 
 		if (time_measure_start) {
-			err = memfault_metrics_heartbeat_timer_start(
-						MEMFAULT_METRICS_KEY(Button1TimeMeasure));
+			err = MEMFAULT_METRIC_TIMER_START(Button1TimeMeasure);
 			if (err) {
 				printk("Failed to start memfault metrics timer: %d\n", err);
 			}
 		} else {
-			err = memfault_metrics_heartbeat_timer_stop(
-						MEMFAULT_METRICS_KEY(Button1TimeMeasure));
+			err = MEMFAULT_METRIC_TIMER_STOP(Button1TimeMeasure);
 			if (err) {
 				printk("Failed to stop memfault metrics: %d\n", err);
 			}
@@ -226,7 +224,7 @@ static void button_handler(uint32_t button_state, uint32_t has_changed)
 	}
 
 	if (buttons & DK_BTN3_MSK) {
-		err = memfault_metrics_heartbeat_add(MEMFAULT_METRICS_KEY(Button3PressCount), 1);
+		err = MEMFAULT_METRIC_ADD(Button3PressCount, 1);
 		if (err) {
 			printk("Failed to increase button press count metrics: %d\n", err);
 		} else {
@@ -259,8 +257,7 @@ static void bas_notify(void)
 		battery_level = 100U;
 	}
 
-	err = memfault_metrics_heartbeat_set_unsigned(MEMFAULT_METRICS_KEY(BatteryLvl),
-						      battery_level);
+	err = MEMFAULT_METRIC_SET_UNSIGNED(BatteryLvl, battery_level);
 	if (err) {
 		printk("Failed to set battery lvl memfault metrics (err %d)\n", err);
 	}

--- a/samples/debug/memfault/src/main.c
+++ b/samples/debug/memfault/src/main.c
@@ -65,8 +65,7 @@ static void button_handler(uint32_t button_states, uint32_t has_changed)
 		ARG_UNUSED(i);
 	} else if (has_changed & DK_BTN3_MSK) {
 		/* DK_BTN3_MSK is Switch 1 on nRF9160 DK. */
-		int err =
-			memfault_metrics_heartbeat_add(MEMFAULT_METRICS_KEY(Switch1ToggleCount), 1);
+		int err = MEMFAULT_METRIC_ADD(Switch1ToggleCount, 1);
 		if (err) {
 			LOG_ERR("Failed to increment Switch1ToggleCount");
 		} else {

--- a/west.yml
+++ b/west.yml
@@ -239,7 +239,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.3.3
+      revision: 1.5.2
       remote: memfault
     - name: ant
       repo-path: sdk-ant


### PR DESCRIPTION
### Summary

We have a new metrics API, so I bumped the memfault version and removed most references to the old API.
The only references I left were in the collection of thread metrics [here](https://github.com/nrfconnect/sdk-nrf/blob/dc672091f5c7dcd2746856e02ac0ba1cf15837d6/modules/memfault-firmware-sdk/memfault_ncs_metrics.c#L74) and in asset tracker debug module unit tests [here](https://github.com/nrfconnect/sdk-nrf/blob/dc672091f5c7dcd2746856e02ac0ba1cf15837d6/applications/asset_tracker_v2/tests/debug_module/src/debug_module_test.c#L116). 
The module that collects thread metrics needs to share references to the metrics with
other modules, so storing the key and using the original metrics API makes sense.
The unit tests will need a reference to the underlying function called for mocking so we can't use
the `MEMFAULT_METRIC_*` macro in this case.

Also fixed some incorrect formatting that slipped through.

### Test Plan

Built with the asset tracker app and confirmed a successful heartbeat pushed to Memfault.