### PR TITLE
Adjust log messages for metric collection errors

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -935,6 +935,7 @@ int modem_info_get_connectivity_stats(int *tx_kbytes, int *rx_kbytes)
 				     tx_kbytes, rx_kbytes);
 
 	if (ret != 2) {
+		LOG_ERR("Could not get connectivity stats, error: %d", ret);
 		return map_nrf_modem_at_scanf_error(ret);
 	}
 
@@ -950,10 +951,12 @@ int modem_info_get_current_band(uint8_t *band)
 	int ret = nrf_modem_at_scanf("AT%XCBAND", "%%XCBAND: %u", band);
 
 	if (ret != 1) {
+		LOG_ERR("Could not get band, error: %d", ret);
 		return map_nrf_modem_at_scanf_error(ret);
 	}
 
 	if (*band == BAND_UNAVAILABLE) {
+		LOG_WRN("No valid band");
 		return -ENOENT;
 	}
 
@@ -970,12 +973,15 @@ int modem_info_get_operator(char *buf, size_t len)
 	int ret = nrf_modem_at_cmd(response, sizeof(response), AT_CMD_XMONITOR);
 
 	if (ret) {
+		LOG_ERR("Could not get modem parameters, error: %d", ret);
 		return map_nrf_modem_at_scanf_error(ret);
 	}
 	int result =
 		sscanf(response, "%%XMONITOR: %*[^,],%*[^,],\"%" STRINGIFY(MAX_SHORT_OP_NAME_SIZE_WITHOUT_NULL_TERM) "[^\"]\",", buf);
 
 	if (result != 1) {
+		// Warning instead of error because it is not always reported
+		LOG_WRN("Operator collection failed, error: %d", ret);
 		return -ENOMSG;
 	}
 
@@ -993,10 +999,12 @@ int modem_info_get_snr(int *snr)
 	int ret = nrf_modem_at_scanf("AT%XSNRSQ?", "%%XSNRSQ: %d,%*d,%*d", snr);
 
 	if (ret != 1) {
+		LOG_ERR("Could not get SNR, error: %d", ret);
 		return map_nrf_modem_at_scanf_error(ret);
 	}
 
 	if (*snr == SNR_UNAVAILABLE) {
+		LOG_WRN("No valid SNR");
 		return -ENOENT;
 	}
 

--- a/modules/memfault-firmware-sdk/memfault_bt_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_bt_metrics.c
@@ -117,11 +117,11 @@ void memfault_bt_metrics_update(void)
 
 	err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_bt_bond_count, bond_count);
 	if (err) {
-		LOG_WRN("Failed to set the ncs_bt_bond_count metric, err: %d", err);
+		LOG_ERR("Failed to set the ncs_bt_bond_count metric, err: %d", err);
 	}
 
 	err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_bt_connection_count, atomic_get(&connection_count));
 	if (err) {
-		LOG_WRN("Failed to set ncs_bt_connection_count metrics, err: %d", err);
+		LOG_ERR("Failed to set ncs_bt_connection_count metrics, err: %d", err);
 	}
 }

--- a/modules/memfault-firmware-sdk/memfault_lte_metrics.c
+++ b/modules/memfault-firmware-sdk/memfault_lte_metrics.c
@@ -47,7 +47,7 @@ static void lte_trace_cb(enum lte_lc_trace_type type)
 
 		err = MEMFAULT_METRIC_TIMER_START(ncs_lte_time_to_connect_ms);
 		if (err) {
-			LOG_WRN("LTE connection time tracking was not started, error: %d", err);
+			LOG_ERR("LTE connection time tracking was not started, error: %d", err);
 		} else {
 			connect_timer_started = true;
 		}
@@ -113,7 +113,6 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 		err = MEMFAULT_METRIC_SET_STRING(ncs_lte_operator, operator_name);
 		if (err) {
 			LOG_ERR("Failed to set ncs_lte_operator");
-			LOG_ERR("Failed to set ncs_lte_band");
 		}
 	}
 #endif
@@ -170,7 +169,7 @@ static void lte_handler(const struct lte_lc_evt *const evt)
 
 				err = MEMFAULT_METRIC_TIMER_START(ncs_lte_time_to_connect_ms);
 				if (err) {
-					LOG_WRN("Failed to start LTE connection timer, error: %d",
+					LOG_ERR("Failed to start LTE connection timer, error: %d",
 						err);
 				} else {
 					LOG_DBG("ncs_lte_time_to_connect_ms started");
@@ -243,7 +242,7 @@ void memfault_lte_metrics_init(void)
 
 	int err = modem_info_connectivity_stats_init();
 	if (err) {
-		LOG_ERR("Failed to init connectivity stats, err: %d", err);
+		LOG_WRN("Failed to init connectivity stats, error: %d", err);
 	}
 #endif
 
@@ -263,7 +262,7 @@ void memfault_lte_metrics_update(void)
 	int rx_kybtes;
 	int err = modem_info_get_connectivity_stats(&tx_kbytes, &rx_kybtes);
 	if (err) {
-		LOG_WRN("LTE connectivity stats collections failed, error: %d", err);
+		LOG_WRN("Failed to collect connectivity stats, error: %d", err);
 	} else {
 		err = MEMFAULT_METRIC_SET_UNSIGNED(ncs_lte_tx_kilobytes, tx_kbytes);
 		if (err) {


### PR DESCRIPTION
### Summary

NCS currently prints log messages when metrics collection fails in some
way. Log levels aren't applied consistently so a few have been updated.
Also, a few were added that were missing. 

Currently we get upon boot:

```
[00:00:02.078,125] <wrn> modem_info: Operator collection failed, error 0
[00:00:02.078,155] <wrn> memfault_ncs_metrics: Network operator collection failed, error: -35
[00:00:02.080,810] <wrn> modem_info: Operator collection failed, error 0
[00:00:02.080,810] <wrn> memfault_ncs_metrics: Network operator collection failed, error: -35
[00:00:02.084,197] <wrn> modem_info: Operator collection failed, error 0
[00:00:02.084,197] <wrn> memfault_ncs_metrics: Network operator collection failed, error: -35
[00:00:02.084,838] <inf> app_event_manager: MODEM_EVT_LTE_CELL_UPDATE
[00:00:02.188,507] <wrn> modem_info: Operator collection failed, error 0
[00:00:02.188,537] <wrn> memfault_ncs_metrics: Network operator collection failed, error: -35
```

and later:

```
[00:01:47.048,828] <wrn> modem_info: No valid RSRP
[00:01:47.048,858] <wrn> memfault_ncs_metrics: LTE RSRP value collection failed, error: -2
[00:01:47.051,147] <wrn> modem_info: No valid SNR
[00:01:47.051,177] <wrn> memfault_ncs_metrics: SNR collection failed, error: -2
[00:01:47.260,833] <wrn> modem_info: No valid RSRP
[00:01:47.260,864] <wrn> memfault_ncs_metrics: LTE RSRP value collection failed, error: -2
[00:01:47.275,207] <wrn> modem_info: No valid SNR
[00:01:47.275,238] <wrn> memfault_ncs_metrics: SNR collection failed, error: -2
```

While not ideal to see right away, these are generally expected; some values are not always available, especially
if a connection has not been established. In the future, moving the collection
of these metrics to a different spot (i.e. for session metrics) might avoid some
of these.

Users can always adjust the log level for memfault within NCS with
`CONFIG_MEMFAULT_NCS_LOG_LEVEL` if they want to turn these off.

### Test Plan

Built locally with thingy91 test app. 