### PR TITLE
Move LTE on-time metric collection to callback

### DIFF
--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -23,10 +23,6 @@
 
 #include "lte_lc_helpers.h"
 
-#if defined(CONFIG_MEMFAULT_NCS_LTE_METRICS)
-#include <memfault/metrics/metrics.h>
-#endif
-
 LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
 /* Internal system mode value used when CONFIG_LTE_NETWORK_MODE_DEFAULT is enabled. */
@@ -1447,14 +1443,6 @@ int lte_lc_func_mode_set(enum lte_lc_func_mode mode)
 		LOG_DBG("CFUN monitor callback: %p", e->callback);
 		e->callback(mode, e->context);
 	}
-
-#if defined(CONFIG_MEMFAULT_NCS_LTE_METRICS)
-  if (mode == LTE_LC_FUNC_MODE_NORMAL || mode == LTE_LC_FUNC_MODE_ACTIVATE_LTE) {
-	  MEMFAULT_METRIC_TIMER_START(ncs_lte_on_time_ms);
-  } else if(mode == LTE_LC_FUNC_MODE_POWER_OFF || mode == LTE_LC_FUNC_MODE_OFFLINE || mode == LTE_LC_FUNC_MODE_DEACTIVATE_LTE) {
-	  MEMFAULT_METRIC_TIMER_STOP(ncs_lte_on_time_ms);
-  }
-#endif
 
 	return 0;
 }


### PR DESCRIPTION
### Summary

To maintain the pattern of Memfault metric collection via callbacks
and not muck with the NCS libraries, the collection of LTE on-time
is now in the callback that the LTE metrics module issues with the
link control library.

Additionally, since 1) calling start on an already running timer or stop
on a stopped timer has no effect and 2) we are not particularly
interested to know when this occurs, we have removed the logic around
catching these cases.

### Test Plan

Flashed thingy91 and issued lte connection updates to validate behavior
of timers.

Note: this reinforces the need for a session since
`ncs_lte_time_to_connect_ms` will be the aggregate of times to connect
if the device needs to connect multiple times in a heartbeat rather than
the time to connect for a singular connection request.

<details>
OT = on-time, TTC = time-to-connect

On boot - TTC stays the same after connection is made, OT increases:

<pre><code>
uart:~$ mflt heartbeat_dump
<inf> mflt:   ncs_lte_time_to_connect_ms: 3111
<inf> mflt:   ncs_lte_on_time_ms: 27049
uart:~$ mflt heartbeat_dump
<inf> mflt:   ncs_lte_time_to_connect_ms: 3111
<inf> mflt:   ncs_lte_on_time_ms: 29299
</code></pre></p>

Normal -> off - TTC increases, OT stays the same:

<pre><code>
uart:~$ lte power_off
uart:~$ mflt heartbeat_dump
[00:00:48.979,339] <inf> mflt:   ncs_lte_time_to_connect_ms: 8077
[00:00:48.979,858] <inf> mflt:   ncs_lte_on_time_ms: 40716
uart:~$ mflt heartbeat_dump
[00:00:51.470,306] <inf> mflt:   ncs_lte_time_to_connect_ms: 10568
[00:00:51.470,825] <inf> mflt:   ncs_lte_on_time_ms: 40716
</code></pre></p>

Off -> Normal - TTC increases then stops, OT starts increasing again:

<pre><code>
uart:~$ lte normal
uart:~$ mflt heartbeat_dump
[00:01:09.411,895] <inf> mflt:   ncs_lte_time_to_connect_ms: 26443
[00:01:09.412,414] <inf> mflt:   ncs_lte_on_time_ms: 45067
uart:~$ mflt heartbeat_dump
[00:01:12.292,633] <inf> mflt:   ncs_lte_time_to_connect_ms: 26443
[00:01:12.293,151] <inf> mflt:   ncs_lte_on_time_ms: 47947
</code></pre></p>

Normal -> Offline - TTC starts increasing again, OT stops increasing:

<pre><code>
uart:~$ lte offline
uart:~$ mflt heartbeat_dump
[00:02:08.426,818] <inf> mflt:   ncs_lte_time_to_connect_ms: 28099
[00:02:08.427,337] <inf> mflt:   ncs_lte_on_time_ms: 100885
uart:~$ mflt heartbeat_dump
[00:02:24.239,044] <inf> mflt:   ncs_lte_time_to_connect_ms: 43911
[00:02:24.239,562] <inf> mflt:   ncs_lte_on_time_ms: 100885
</code></pre></p>

Offline -> Normal - TTC increases then stops, OT starts increasing again:

<pre><code>
uart:~$ lte normal
uart:~$ mflt heartbeat_dump
[00:02:36.588,012] <inf> mflt:   ncs_lte_time_to_connect_ms: 53900
[00:02:36.588,531] <inf> mflt:   ncs_lte_on_time_ms: 105451
uart:~$ mflt heartbeat_dump
[00:02:38.279,510] <inf> mflt:   ncs_lte_time_to_connect_ms: 53900
[00:02:38.280,029] <inf> mflt:   ncs_lte_on_time_ms: 107142
</code></pre></p>
</details>

---

Resolves: MFLT-13342