### PR TITLE
docs(memfault): suggest Memfault in NCS docs

### DIFF
--- a/doc/nrf/device_guides/working_with_nrf/nrf52/features.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf52/features.rst
@@ -150,3 +150,14 @@ The nRF52 Series devices support running another protocol in parallel with the S
 See the :ref:`ug_multiprotocol_support` user guide on how to enable multiprotocol support for Thread or Zigbee in combination with Bluetooth.
 
 The :ref:`nrfxlib:mpsl` library provides services for multiprotocol applications.
+
+Remote observability using Memfault
+***********************************
+
+The |NCS| bundles support for remotely monitoring and debugging device fleets.
+This support enables quicker identification and triage of issues in the field and optimizes connection quality and battery life for global deployments.
+The collection system has been optimized to work in intermittent connectivity environments and has extremely low overhead.
+
+The |NCS| includes out-of-the-box metrics collected for monitoring Bluetooth connectivity, such as connection time and Bluetooth thread stack usage on nRF52 Series SoCs as well as a GATT profile and example apps for easily sending the data through a mobile phone gateway.
+
+See the :ref:`ug_memfault` page for more information on how to enable Memfault in your |NCS| project on an nRF52 Series device and visualize the data across the fleet and by device.

--- a/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_features.rst
+++ b/doc/nrf/device_guides/working_with_nrf/nrf91/nrf91_features.rst
@@ -165,7 +165,6 @@ The :ref:`nrfxlib:nrf_modem` is released as an OS-independent binary library in 
 
 The Modem library integration layer fulfills the integration requirements of the Modem library in |NCS|.
 For more information on the integration, see :ref:`nrf_modem_lib_readme`.
-
 .. nrf91_modem_lib_end
 
 .. _modem_trace:
@@ -189,6 +188,23 @@ For more information on the implementation of a custom trace backend, see :ref:`
 
 .. _nrf91_fota:
 .. _nrf9160_fota:
+
+Remote observability using Memfault
+***********************************
+
+The |NCS| bundles support for remotely monitoring and debugging device fleets.
+This support enables quicker identification and triage of issues in the field, and optimizes connection quality and battery life for global deployments.
+The collection system has been optimized to work in intermittent connectivity environments and has extremely low overhead.
+
+The cellular stack consists of out-of-the-box collection of the following key connectivity health vitals:
+* Total bytes sent and received
+* The network operator
+* Frequency band
+* Signal quality measurements
+
+For debugging, any system crashes and modem traces can be remotely collected for further analysis.
+
+See the :ref:`ug_memfault` page for more information on how to enable Memfault in your |NCS| project on an nRF91 Series SiP to visualize the data across the fleet and by device.
 
 FOTA updates
 ************

--- a/doc/nrf/external_comp/memfault.rst
+++ b/doc/nrf/external_comp/memfault.rst
@@ -15,7 +15,7 @@ Memfault integration provides the following features to |NCS|:
 * `Continuous monitoring <Memfault monitoring_>`_ - Monitors device and fleet-level metrics like connectivity and low power state in real-time dashboards and displays prepopulated metrics for your devices.
   You can access device level data to resolve bugs faster.
 
-See the `Memfault documentation <Memfault introduction_>`_ for more details.
+See the `Memfault sandbox <Memfault Sandbox_>`_ for a self guided tour of the platform as well as the `Memfault documentation <Memfault introduction_>`_ for more details.
 
 .. note::
    Memfault has been integrated in |NCS| since the v1.6.0 release.

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -24,11 +24,15 @@ Robust connectivity support
   The |NCS| supports a wide range of connectivity technologies.
   In addition to connectivity technologies :ref:`provided by Zephyr <zephyr:connectivity>`, such as Bluetooth® Low Energy, IPv6, TCP/IP, UDP, LoRa and LoRaWAN, the |NCS| supports ANT, Bluetooth Mesh, Apple Find My, LTE-M/NB-IoT/GPS, Matter, Amazon Sidewalk, Thread, and Wi-Fi®, among others.
 
+Remote observability
+  The |NCS| provides remote observability support to maintain optimal device performance and reliability in ever-changing device ecosystems after devices are deployed.
+  Once devices are in the field, you can implement device reliability best practices such as remote debug, monitoring, and FOTA support.
+
 Scalable and extensible
   The |NCS| is out-of-tree ready and can be used for projects and applications of all sizes and levels of complexity.
 
 Third-party integrations
-  The |NCS| provides integrations with third-party and Nordic products within the SDK, such as AWS, nRF Cloud, Memfault, and more.
+  The |NCS| provides integrations with third-party and Nordic products within the SDK, such as AWS, nRF Cloud, :ref:`Memfault (Remote Observability) <ug_memfault>` and more.
 
 Varied reference designs
   The |NCS| comes with advanced hardware reference designs for different use cases, ranging from nRF Desktop for Human Interface Devices to nRF5340 Audio for audio devices based on Bluetooth LE Audio specifications.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -1110,6 +1110,7 @@
 .. _`Memfault MCU Guide`: https://docs.memfault.com/docs/mcu/introduction
 .. _`Memfault: Reboot tracking`: https://docs.memfault.com/docs/mcu/reboot-reason-tracking
 .. _`Memfault: Coredumps`: https://docs.memfault.com/docs/mcu/coredumps
+.. _`Memfault Sandbox`: https://mflt.io/demo
 
 .. ### Source: *.nrfcloud.com
 

--- a/doc/nrf/test_and_optimize/debugging.rst
+++ b/doc/nrf/test_and_optimize/debugging.rst
@@ -133,6 +133,17 @@ Use the following steps to enable monitor-mode debugging in the |NCS|:
 
 For more information about monitor-mode debugging, see Zephyr's :ref:`zephyr:debugmon` documentation and SEGGER's `Monitor-mode Debugging <Monitor-mode Debugging_>`_ documentation.
 
+
+Remote debugging using Memfault
+*******************************
+
+The |NCS| provides remote observability support to maintain optimal device performance and reliability in ever-changing device ecosystems.
+As you start to rollout a fleet, you can debug and monitor devices remotely.
+
+This functionality allows you to efficiently collect crash information and get the same data from remote devices as you would when using a debugger.
+
+For more information on enabling remote debugging with the |NCS| see :ref:`ug_memfault`.
+
 .. _debugging_tools:
 
 Debugging tools


### PR DESCRIPTION
 ### Summary

 Mention Memfault in the top-level NCS page, device pages, and debugging
 page. The `:ref:` link points to [Memfault's integration page](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/external_comp/memfault.html)
 in the NCS docs.

 ### Test Plan

 - Built the docs successfully via CI. Rendered pages:

Landing page:

<img width="944" alt="Screenshot 2024-05-10 at 1 27 50 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/e183aea0-b945-4010-86ce-3df524cfbc8c">
<img width="951" alt="Screenshot 2024-05-10 at 1 27 54 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/c8930baa-3984-4103-830f-1198f72c8ea5">

A device features page:

<img width="974" alt="Screenshot 2024-05-10 at 1 28 54 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/a0f03c82-3230-450b-91f7-d3a99e26c3ab">

Debugging page:

<img width="975" alt="Screenshot 2024-05-10 at 1 29 59 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/c08ac1b7-ca5f-4e0d-9d42-f8d85a69dff6">

Integration page:

<img width="620" alt="Screenshot 2024-05-10 at 1 29 36 PM" src="https://github.com/memfault/sdk-nrf/assets/41022382/7501762e-07f7-4a6d-9683-8f22cf4dd63e">



---

Resolves: MCU-377