### PR TITLE
feat: update memfault sdk to 1.19.0

### DIFF
--- a/applications/asset_tracker_v2/configuration/memfault/memfault_platform_config.h
+++ b/applications/asset_tracker_v2/configuration/memfault/memfault_platform_config.h
@@ -7,7 +7,5 @@
  */
 
 #if defined(CONFIG_DEBUG_MODULE)
- /* Prepare captured metric data for upload to Memfault cloud every configured interval. */
-#define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS CONFIG_DEBUG_MODULE_MEMFAULT_HEARTBEAT_INTERVAL_SEC
 #define MEMFAULT_DATA_EXPORT_CHUNK_MAX_LEN CONFIG_DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX
 #endif /* defined(CONFIG_DEBUG_MODULE) */

--- a/applications/asset_tracker_v2/doc/debug_module.rst
+++ b/applications/asset_tracker_v2/doc/debug_module.rst
@@ -52,11 +52,6 @@ Configuration options
 CONFIG_DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT - Configuration for transfer of Memfault data
    This option, if enabled, makes the debug module trigger events carrying Memfault data. This data can be routed through an external transport to Memfault cloud, for example, through AWS IoT, Azure IoT Hub, or `nRF Cloud`_.
 
-.. _CONFIG_DEBUG_MODULE_MEMFAULT_HEARTBEAT_INTERVAL_SEC:
-
-CONFIG_DEBUG_MODULE_MEMFAULT_HEARTBEAT_INTERVAL_SEC - Configuration for nRF Connect SDK Memfault metrics tracking interval
-   This option sets the time interval for tracking |NCS| Memfault metrics.
-
 .. _CONFIG_DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX:
 
 CONFIG_DEBUG_MODULE_MEMFAULT_CHUNK_SIZE_MAX - Configuration for maximum size of transmitted packets

--- a/applications/asset_tracker_v2/overlay-memfault.conf
+++ b/applications/asset_tracker_v2/overlay-memfault.conf
@@ -12,6 +12,10 @@ CONFIG_MEMFAULT_NCS_STACK_METRICS=y
 CONFIG_MEMFAULT_NCS_LOCATION_METRICS=y
 CONFIG_MEMFAULT_LOGGING_ENABLE=y
 
+# Configuration that sets how often Memfault captures and prepares data that will be sent
+# to Memfault cloud. Reduced from the default 1 hour interval here for demonstration.
+CONFIG_MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS=1800
+
 CONFIG_MEMFAULT_ROOT_CERT_STORAGE_NRF9160_MODEM=y
 # There is a race with the credential provisioning and starting LTE network search if automatic
 # provisioning is used. Therefore it's disabled, and the app controls it.

--- a/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
+++ b/applications/asset_tracker_v2/src/modules/Kconfig.debug_module
@@ -33,16 +33,6 @@ config DEBUG_MODULE_MEMFAULT_USE_EXTERNAL_TRANSPORT
 	  The AWS IoT configuration of the application is the only implementation that currently
 	  supports this option.
 
-config DEBUG_MODULE_MEMFAULT_HEARTBEAT_INTERVAL_SEC
-	int "Memfault heartbeat interval in seconds"
-	default 1800
-	help
-	  Configuration that sets how often Memfault captures and prepares data that will be sent
-	  to Memfault cloud. Reduce this interval to get more frequent updates to Memfault.
-	  Note that data transmitted to Memfault cloud is still dependent on how often the
-	  application sends data, which can be manipulated by setting the application's real-time
-	  configurations.
-
 config DEBUG_MODULE_MEMFAULT_WATCHDOG_DELTA_MS
 	int "Memfault software watchdog delta"
 	default 5000

--- a/samples/bluetooth/peripheral_mds/memfault_config/memfault_platform_config.h
+++ b/samples/bluetooth/peripheral_mds/memfault_config/memfault_platform_config.h
@@ -9,4 +9,3 @@
  * "<NCS folder>/modules/lib/memfault-firmware-sdk/components/include/memfault/default_config.h"
  */
 
- /* #define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS 1800 */

--- a/samples/debug/memfault/config/memfault_platform_config.h
+++ b/samples/debug/memfault/config/memfault_platform_config.h
@@ -12,10 +12,3 @@
  * "<NCS folder>/modules/lib/memfault-firmware-sdk/components/include/memfault/default_config.h"
  */
 
-/* Uncomment the definition below to override the default setting for
- * heartbeat interval. This will prepare the captured metric data for upload
- * to Memfault cloud at the specified interval.
- */
-/*
- * #define MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS 1800
- */

--- a/west.yml
+++ b/west.yml
@@ -262,7 +262,7 @@ manifest:
       remote: throwtheswitch
     - name: memfault-firmware-sdk
       path: modules/lib/memfault-firmware-sdk
-      revision: 1.12.0
+      revision: 1.19.0
       remote: memfault
     - name: bsim
       repo-path: bsim_west


### PR DESCRIPTION
### Summary

 In Memfault SDK 1.19.0, the config `MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS` set via
`memfault_platform_config.h` was replaced with the Kconfig
`CONFIG_MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS`.
This commit updates the SDK version and:
 - Removes debug module Kconfig in the asset tracker app for the
heartbeat interval, this is unnecessary wrapping now that the
Memfault Zephyr module has a Kconfig
 - Removes references to the old config
 - Adds example usage of `CONFIG_MEMFAULT_METRICS_HEARTBEAT_INTERVAL_SECS`

 ### Test Plan

 Confirmed successful build of asset tracker app:

 ```
 west build -b thingy91/nrf9160/ns --sysbuild -p always nrf/applications/asset_tracker_v2 -- \
    -DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"$(<~/.memfault-gilly-playground-proj-key)\" \
    -DOVERLAY_CONFIG=overlay-memfault.conf
 ```

Resolves: MCU-862