### PR TITLE
feat: allow empty Memfault project key

### DIFF
--- a/modules/memfault-firmware-sdk/memfault_integration.c
+++ b/modules/memfault-firmware-sdk/memfault_integration.c
@@ -35,9 +35,11 @@ LOG_MODULE_REGISTER(memfault_ncs, CONFIG_MEMFAULT_NCS_LOG_LEVEL);
 #define MEMFAULT_URL	"https://goto.memfault.com/create-key/nrf"
 #endif
 
+#if defined(CONFIG_BT_MDS) || defined(CONFIG_MEMFAULT_HTTP_ENABLE)
 /* Project key check */
 BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_PROJECT_KEY) > 1,
 	"Memfault Project Key not configured. Please visit " MEMFAULT_URL " ");
+#endif
 
 /* Firmware type check */
 BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_FW_TYPE) > 1, "Firmware type must be configured");


### PR DESCRIPTION
### Summary

 In cases where an upstream device uploads data to Memfault on behalf
 of a downstream device, the project key is not required. This change
 allows the project key to be optional in those cases. For the
 NCS Memfault sources, this is when we are not using MDS or the
Memfault Zephyr HTTP client.

 ### Test Plan

 Confirmed that before this change, the build fails if the project key
 is not set for a generic cortex-m application where Memfault is enabled:

 ```
 west build -b qemu_cortex_m3
 zephyr/samples/hello_world -- \
 -DCONFIG_MEMFAULT=y \
 -DCONFIG_MEMFAULT_NCS_FW_TYPE=\"test-app\" \
 -DCONFIG_MEMFAULT_NCS_DEVICE_ID=\"my-test-device\"
 ```

 Confirmed after this change, the build succeeds with this same build command.

 Also confirmed that after this change, the build still fails if the project key
 is not set for projects where MDS or the Memfault Zephyr HTTP client
 are used:

  ```
west build -b nrf52840dk/nrf52840 \
nrf/samples/bluetooth/peripheral_mds
  ...
/Users/gminnehan/projects/memfault-sdk-nrf-workspace/zephyr/include/zephyr/toolchain/gcc.h:87:36: error: static assertion failed: "Memfault Project Key not configured. Please visit https://goto.memfault.com/create-key/nrf "
   87 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert((EXPR), "" MSG)
      |                                    ^~~~~~~~~~~~~~
/Users/gminnehan/projects/memfault-sdk-nrf-workspace/nrf/modules/memfault-firmware-sdk/memfault_integration.c:40:1: note: in expansion of macro 'BUILD_ASSERT'
   40 | BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_PROJECT_KEY) > 1,
      | ^~~~~~~~~~~~
  ```

  ```
  west build -b thingy91/nrf9160/ns -p always \
  nrf/applications/asset_tracker_v2 -- \
  -DOVERLAY_CONFIG=overlay-memfault.conf
  ...
  /Users/gminnehan/projects/memfault-sdk-nrf-workspace/zephyr/include/zephyr/toolchain/gcc.h:87:36: error: static assertion failed: "Memfault Project Key not configured. Please visit https://goto.memfault.com/create-key/nrf91 "
   87 | #define BUILD_ASSERT(EXPR, MSG...) _Static_assert((EXPR), "" MSG)
      |                                    ^~~~~~~~~~~~~~
/Users/gminnehan/projects/memfault-sdk-nrf-workspace/nrf/modules/memfault-firmware-sdk/memfault_integration.c:40:1: note: in expansion of macro 'BUILD_ASSERT'
   40 | BUILD_ASSERT(sizeof(CONFIG_MEMFAULT_NCS_PROJECT_KEY) > 1,
      | ^~~~~~~~~~~~
  ```
 and still succeeds when the project key is passed:

```
west build -b nrf52840dk/nrf52840 \
nrf/samples/bluetooth/peripheral_mds -- \
-DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"$(<~/.memfault-gilly-playground-proj-key)\"
```

```
west build -b thingy91/nrf9160/ns \
nrf/applications/asset_tracker_v2 -- \
-DCONFIG_MEMFAULT_NCS_PROJECT_KEY=\"$(<~/.memfault-gilly-playground-proj-key)\" \
-DOVERLAY_CONFIG=overlay-memfault.conf
```

---
Resolve: MCU-982